### PR TITLE
refactor: EventStoreForMemory constructor and EventStoreFactory#ofMemory

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -72,6 +72,9 @@ const eventStore = EventStoreFactory.ofDynamoDB<
     convertJSONtoUserAccountEvent,
     convertJSONToUserAccount,
 );
+// if you want to use in-memory event store, use the following code.
+// const eventStore = EventStoreFactory.ofMemory<UserAccountId, UserAccount, UserAccountEvent>();
+
 const userAccountRepository = new UserAccountRepository(eventStore);
 
 const id = new UserAccountId(ulid());

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ const eventStore = EventStoreFactory.ofDynamoDB<
     convertJSONtoUserAccountEvent,
     convertJSONToUserAccount,
 );
+// if you want to use in-memory event store, use the following code.
+// const eventStore = EventStoreFactory.ofMemory<UserAccountId, UserAccount, UserAccountEvent>();
+
 const userAccountRepository = new UserAccountRepository(eventStore);
 
 const id = new UserAccountId(ulid());

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -78,7 +78,10 @@ class EventStoreFactory {
     AID extends AggregateId,
     A extends Aggregate<A, AID>,
     E extends Event<AID>,
-  >(events: Map<AID, E[]>, snapshots: Map<AID, A>): EventStore<AID, A, E> {
+  >(
+    events: Map<AID, E[]> = new Map(),
+    snapshots: Map<AID, A> = new Map(),
+  ): EventStore<AID, A, E> {
     return new EventStoreForMemory(events, snapshots);
   }
 }

--- a/src/internal/event-store-for-memory.test.ts
+++ b/src/internal/event-store-for-memory.test.ts
@@ -1,10 +1,9 @@
 import { describe } from "node:test";
 import { UserAccountId } from "./test/user-account-id";
-// import {ulid} from "ulid";
 import { UserAccount } from "./test/user-account";
 import { UserAccountEvent } from "./test/user-account-event";
-import { EventStore } from "../event-store";
-import { EventStoreForMemory } from "./event-store-for-memory";
+import { EventStore, EventStoreFactory } from "../event-store";
+import { ulid } from "ulid";
 
 afterEach(() => {
   jest.useRealTimers();
@@ -21,11 +20,11 @@ describe("EventStoreForDynamoDB", () => {
     UserAccount,
     UserAccountEvent
   > {
-    return new EventStoreForMemory<
+    return EventStoreFactory.ofMemory<
       UserAccountId,
       UserAccount,
       UserAccountEvent
-    >(new Map(), new Map());
+    >();
   }
 
   beforeAll(async () => {
@@ -35,7 +34,7 @@ describe("EventStoreForDynamoDB", () => {
   test(
     "persistAndSnapshot",
     async () => {
-      const id = new UserAccountId("1");
+      const id = new UserAccountId(ulid());
       const name = "Alice";
       const [userAccount1, created] = UserAccount.create(id, name);
 
@@ -55,7 +54,7 @@ describe("EventStoreForDynamoDB", () => {
   test(
     "persistAndSnapshot2",
     async () => {
-      const id = new UserAccountId("2");
+      const id = new UserAccountId(ulid());
       const name = "Alice";
       const [userAccount1, created] = UserAccount.create(id, name);
 

--- a/src/internal/event-store-for-memory.ts
+++ b/src/internal/event-store-for-memory.ts
@@ -10,7 +10,10 @@ class EventStoreForMemory<
   private readonly events: Map<string, E[]>;
   private readonly snapshots: Map<string, A>;
 
-  constructor(events: Map<AID, E[]>, snapshots: Map<AID, A>) {
+  constructor(
+    events: Map<AID, E[]> = new Map(),
+    snapshots: Map<AID, A> = new Map(),
+  ) {
     this.events = new Map(
       Array.from(events).map(([key, values]) => {
         return [key.asString, values];


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added an alternative way to initialize the `eventStore` using the `EventStoreFactory.ofMemory` method. This allows developers to create an in-memory event store, which can be useful for testing and development scenarios.
- Refactor: Updated the `EventStoreFactory#ofMemory` method and the `EventStoreForMemory` constructor to have default parameters for `events` and `snapshots`. This simplifies the creation of new instances.
- Test: Refactored tests for `EventStoreForMemory` to use the updated constructor and the `ulid` function for generating unique identifiers. This improves test reliability and consistency.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->