### PR TITLE
fix: typeName

### DIFF
--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -73,7 +73,6 @@ class EventStoreFactory {
       snapshotSerializer,
     );
   }
-
   static ofMemory<
     AID extends AggregateId,
     A extends Aggregate<A, AID>,

--- a/src/internal/default-serializer.ts
+++ b/src/internal/default-serializer.ts
@@ -19,7 +19,7 @@ class JsonEventSerializer<AID extends AggregateId, E extends Event<AID>>
 
   serialize(event: E): Uint8Array {
     const jsonString = JSON.stringify({
-      type: event.constructor.name,
+      type: event.typeName,
       data: event,
     });
     return this.encoder.encode(jsonString);
@@ -40,7 +40,7 @@ class JsonSnapshotSerializer<
 
   serialize(aggregate: A): Uint8Array {
     const jsonString = JSON.stringify({
-      type: aggregate.constructor.name,
+      type: aggregate.typeName,
       data: aggregate,
     });
     return this.encoder.encode(jsonString);

--- a/src/internal/test/user-account-event.ts
+++ b/src/internal/test/user-account-event.ts
@@ -4,6 +4,7 @@ import { convertJSONToUserAccountId, UserAccountId } from "./user-account-id";
 interface UserAccountEvent extends Event<UserAccountId> {}
 
 class UserAccountCreated implements UserAccountEvent {
+  public readonly typeName: string = "UserAccountCreated";
   public readonly isCreated: boolean = true;
 
   constructor(
@@ -16,6 +17,7 @@ class UserAccountCreated implements UserAccountEvent {
 }
 
 class UserAccountRenamed implements UserAccountEvent {
+  public readonly typeName: string = "UserAccountRenamed";
   public readonly isCreated: boolean = false;
   constructor(
     public readonly id: string,

--- a/src/internal/test/user-account.ts
+++ b/src/internal/test/user-account.ts
@@ -8,6 +8,7 @@ import {
 } from "./user-account-event";
 
 class UserAccount implements Aggregate<UserAccount, UserAccountId> {
+  public readonly typeName: string = "UserAccount";
   constructor(
     public readonly id: UserAccountId,
     public readonly name: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ interface Aggregate<
   This extends Aggregate<This, AID>,
   AID extends AggregateId,
 > {
+  typeName: string;
   id: AID;
   sequenceNumber: number;
   version: number;
@@ -16,6 +17,7 @@ interface Aggregate<
 }
 
 interface Event<AID extends AggregateId> {
+  typeName: string;
   id: string;
   aggregateId: AID;
   sequenceNumber: number;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the serialization process in `JsonEventSerializer` and `JsonSnapshotSerializer` classes to use a new `typeName` property instead of the constructor name. This change enhances the flexibility and reliability of type determination during serialization.
- New Feature: Added a new `typeName` property to the `Aggregate` and `Event` interfaces, which will now be required for all implementing objects. This addition provides a more explicit and reliable way to determine the type of an event or aggregate.
- Test: Extended test classes `UserAccountCreated`, `UserAccountRenamed`, and `UserAccount` with the new `typeName` property to ensure compatibility with updated interfaces.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->