### PR TITLE
fix: converter interface

### DIFF
--- a/src/internal/default-serializer.ts
+++ b/src/internal/default-serializer.ts
@@ -12,9 +12,11 @@ class JsonEventSerializer<AID extends AggregateId, E extends Event<AID>>
   private encoder = new TextEncoder();
   private decoder = new TextDecoder();
 
-  deserialize(bytes: Uint8Array, converter: (json: string) => E): E {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deserialize(bytes: Uint8Array, converter: (json: any) => E): E {
     const jsonString = this.decoder.decode(bytes);
-    return converter(jsonString);
+    const json = JSON.parse(jsonString);
+    return converter(json);
   }
 
   serialize(event: E): Uint8Array {
@@ -33,9 +35,11 @@ class JsonSnapshotSerializer<
 {
   private encoder = new TextEncoder();
   private decoder = new TextDecoder();
-  deserialize(bytes: Uint8Array, converter: (json: string) => A): A {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deserialize(bytes: Uint8Array, converter: (json: any) => A): A {
     const jsonString = this.decoder.decode(bytes);
-    return converter(jsonString);
+    const obj = JSON.parse(jsonString);
+    return converter(obj);
   }
 
   serialize(aggregate: A): Uint8Array {

--- a/src/internal/test/user-account-event.ts
+++ b/src/internal/test/user-account-event.ts
@@ -28,30 +28,28 @@ class UserAccountRenamed implements UserAccountEvent {
   ) {}
 }
 
-function convertJSONtoUserAccountEvent(jsonString: string): UserAccountEvent {
-  const obj = JSON.parse(jsonString);
-  const aggregateId = convertJSONToUserAccountId(
-    JSON.stringify(obj.data.aggregateId),
-  );
-  switch (obj.type) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function convertJSONtoUserAccountEvent(json: any): UserAccountEvent {
+  const aggregateId = convertJSONToUserAccountId(json.data.aggregateId);
+  switch (json.type) {
     case "UserAccountCreated":
       return new UserAccountCreated(
-        obj.data.id,
+        json.data.id,
         aggregateId,
-        obj.data.name,
-        obj.data.sequenceNumber,
-        obj.data.occurredAt,
+        json.data.name,
+        json.data.sequenceNumber,
+        json.data.occurredAt,
       );
     case "UserAccountRenamed":
       return new UserAccountRenamed(
-        obj.data.id,
+        json.data.id,
         aggregateId,
-        obj.data.name,
-        obj.data.sequenceNumber,
-        obj.data.occurredAt,
+        json.data.name,
+        json.data.sequenceNumber,
+        json.data.occurredAt,
       );
     default:
-      throw new Error(`Unknown type: ${obj.type}`);
+      throw new Error(`Unknown type: ${json.type}`);
   }
 }
 

--- a/src/internal/test/user-account-id.ts
+++ b/src/internal/test/user-account-id.ts
@@ -9,9 +9,9 @@ class UserAccountId implements AggregateId {
   }
 }
 
-function convertJSONToUserAccountId(jsonString: string): UserAccountId {
-  const obj = JSON.parse(jsonString);
-  return new UserAccountId(obj.value);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function convertJSONToUserAccountId(json: any): UserAccountId {
+  return new UserAccountId(json.value);
 }
 
 export { UserAccountId, convertJSONToUserAccountId };

--- a/src/internal/test/user-account.ts
+++ b/src/internal/test/user-account.ts
@@ -93,14 +93,14 @@ class UserAccount implements Aggregate<UserAccount, UserAccountId> {
   }
 }
 
-function convertJSONToUserAccount(jsonString: string): UserAccount {
-  const obj = JSON.parse(jsonString);
-  const id = convertJSONToUserAccountId(JSON.stringify(obj.data.id));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function convertJSONToUserAccount(json: any): UserAccount {
+  const id = convertJSONToUserAccountId(json.data.id);
   return new UserAccount(
     id,
-    obj.data.name,
-    obj.data.sequenceNumber,
-    obj.data.version,
+    json.data.name,
+    json.data.sequenceNumber,
+    json.data.version,
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,8 @@ interface KeyResolver<AID extends AggregateId> {
 
 interface EventSerializer<AID extends AggregateId, E extends Event<AID>> {
   serialize(event: E): Uint8Array;
-
-  deserialize(bytes: Uint8Array, converter: (json: string) => E): E;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deserialize(bytes: Uint8Array, converter: (json: any) => E): E;
 }
 
 interface SnapshotSerializer<
@@ -42,8 +42,8 @@ interface SnapshotSerializer<
   A extends Aggregate<A, AID>,
 > {
   serialize(aggregate: A): Uint8Array;
-
-  deserialize(bytes: Uint8Array, converter: (json: string) => A): A;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deserialize(bytes: Uint8Array, converter: (json: any) => A): A;
 }
 
 export interface Logger {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated `deserialize` methods in `JsonEventSerializer` and `JsonSnapshotSerializer` classes to parse JSON strings into objects before passing them to the converter function. This change improves the efficiency of data processing.
- Refactor: Modified `convertJSONtoUserAccountEvent`, `convertJSONToUserAccountId`, and `convertJSONToUserAccount` functions to accept objects directly, eliminating the need for parsing JSON strings. This simplifies the conversion process and enhances performance.
- Chore: Disabled ESLint rule '@typescript-eslint/no-explicit-any' in certain areas to accommodate necessary type changes.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->