### PR TITLE
fix: asString

### DIFF
--- a/src/internal/default-key-resolver.ts
+++ b/src/internal/default-key-resolver.ts
@@ -18,7 +18,7 @@ class DefaultKeyResolver<AID extends AggregateId> implements KeyResolver<AID> {
     if (aggregateId === undefined || aggregateId === null) {
       throw new Error(`aggregateId is undefined or null: ${aggregateId}`);
     }
-    const hash = this.hashString(aggregateId.asString);
+    const hash = this.hashString(aggregateId.asString());
     const remainder = hash % shardCount;
     return `${aggregateId.typeName}-${remainder}`;
   }

--- a/src/internal/event-store-for-dynamodb.ts
+++ b/src/internal/event-store-for-dynamodb.ts
@@ -76,7 +76,7 @@ class EventStoreForDynamoDB<
         "#seq_nr": "seq_nr",
       },
       ExpressionAttributeValues: {
-        ":aid": { S: id.asString },
+        ":aid": { S: id.asString() },
         ":seq_nr": { N: sequenceNumber.toString() },
       },
     };
@@ -119,7 +119,7 @@ class EventStoreForDynamoDB<
         "#seq_nr": "seq_nr",
       },
       ExpressionAttributeValues: {
-        ":aid": { S: id.asString },
+        ":aid": { S: id.asString() },
         ":seq_nr": { N: "0" },
       },
       Limit: 1,
@@ -165,9 +165,9 @@ class EventStoreForDynamoDB<
   }
 
   async persistEventAndSnapshot(event: E, aggregate: A): Promise<void> {
-    if (event.aggregateId.asString !== aggregate.id.asString) {
+    if (event.aggregateId.asString() !== aggregate.id.asString()) {
       throw new Error(
-        `aggregateId mismatch: expected ${event.aggregateId.asString}, got ${aggregate.id.asString}`,
+        `aggregateId mismatch: expected ${event.aggregateId.asString()}, got ${aggregate.id.asString()}`,
       );
     }
     this.logger?.debug(
@@ -364,7 +364,7 @@ class EventStoreForDynamoDB<
       Item: {
         pkey: { S: pkey },
         skey: { S: skey },
-        aid: { S: event.aggregateId.asString },
+        aid: { S: event.aggregateId.asString() },
         seq_nr: { N: event.sequenceNumber.toString() },
         payload: { B: payload },
         occurred_at: { N: event.occurredAt.getUTCMilliseconds().toString() },
@@ -397,7 +397,7 @@ class EventStoreForDynamoDB<
         pkey: { S: pkey },
         skey: { S: skey },
         payload: { B: payload },
-        aid: { S: event.aggregateId.asString },
+        aid: { S: event.aggregateId.asString() },
         seq_nr: { N: sequenceNumber.toString() },
         version: { N: "1" },
         ttl: { N: "0" },
@@ -510,7 +510,7 @@ class EventStoreForDynamoDB<
         "#aid": "aid",
       },
       ExpressionAttributeValues: {
-        ":aid": { S: aggregateId.asString },
+        ":aid": { S: aggregateId.asString() },
       },
       Select: "COUNT",
     };
@@ -526,7 +526,7 @@ class EventStoreForDynamoDB<
       "#seq_nr": "seq_nr",
     };
     const values = {
-      ":aid": { S: aggregateId.asString },
+      ":aid": { S: aggregateId.asString() },
       ":seq_nr": { N: "0" },
     };
     const request: QueryCommandInput = {

--- a/src/internal/event-store-for-memory.ts
+++ b/src/internal/event-store-for-memory.ts
@@ -16,12 +16,12 @@ class EventStoreForMemory<
   ) {
     this.events = new Map(
       Array.from(events).map(([key, values]) => {
-        return [key.asString, values];
+        return [key.asString(), values];
       }),
     );
     this.snapshots = new Map(
       Array.from(snapshots).map(([key, value]) => {
-        return [key.asString, value];
+        return [key.asString(), value];
       }),
     );
   }
@@ -30,17 +30,17 @@ class EventStoreForMemory<
     if (event.isCreated) {
       throw new Error("event is created");
     }
-    const aggregateIdString = event.aggregateId.asString;
+    const aggregateIdString = event.aggregateId.asString();
     const snapshot = this.snapshots.get(aggregateIdString);
     if (snapshot === undefined) {
       throw new Error("snapshot is undefined");
     }
-    if (snapshot.id.asString !== event.aggregateId.asString) {
+    if (snapshot.id.asString() !== event.aggregateId.asString()) {
       throw new Error(
         "aggregateId mismatch: snapshot.id = " +
-          snapshot.id.asString +
+          snapshot.id.asString() +
           ", event.aggregateId = " +
-          event.aggregateId.asString,
+          event.aggregateId.asString(),
       );
     }
     if (snapshot.version !== version) {
@@ -58,12 +58,12 @@ class EventStoreForMemory<
   }
 
   async persistEventAndSnapshot(event: E, aggregate: A): Promise<void> {
-    if (event.aggregateId.asString !== aggregate.id.asString) {
+    if (event.aggregateId.asString() !== aggregate.id.asString()) {
       throw new Error(
-        `aggregateId mismatch: expected ${event.aggregateId.asString}, got ${aggregate.id.asString}`,
+        `aggregateId mismatch: expected ${event.aggregateId.asString()}, got ${aggregate.id.asString()}`,
       );
     }
-    const aggregateIdString = event.aggregateId.asString;
+    const aggregateIdString = event.aggregateId.asString();
     const events = this.events.get(aggregateIdString) ?? [];
     const snapshot = this.snapshots.get(aggregateIdString) ?? aggregate;
 
@@ -85,7 +85,7 @@ class EventStoreForMemory<
     id: AID,
     sequenceNumber: number,
   ): Promise<E[]> {
-    const aggregateIdString = id.asString;
+    const aggregateIdString = id.asString();
     const events = this.events.get(aggregateIdString);
     if (events === undefined) {
       throw new Error("events is undefined");
@@ -94,7 +94,7 @@ class EventStoreForMemory<
   }
 
   async getLatestSnapshotById(id: AID): Promise<A | undefined> {
-    const aggregateIdString = id.asString;
+    const aggregateIdString = id.asString();
     return this.snapshots.get(aggregateIdString);
   }
 }

--- a/src/internal/test/user-account-id.ts
+++ b/src/internal/test/user-account-id.ts
@@ -4,7 +4,7 @@ class UserAccountId implements AggregateId {
   public readonly typeName = "user-account";
   constructor(public readonly value: string) {}
 
-  get asString(): string {
+  asString(): string {
     return `${this.typeName}-${this.value}`;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 interface AggregateId {
   typeName: string;
   value: string;
-  asString: string;
+  asString: () => string;
 }
 
 interface Aggregate<


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Changed `asString` from a getter property to a method in the `UserAccountId` class and the `AggregateId` interface. This change enhances flexibility and consistency in our codebase.
- Refactor: Updated usage of `aggregateId.asString` across `DefaultKeyResolver`, `EventStoreForDynamoDB`, and `EventStoreForMemory` classes to reflect the above changes. This ensures compatibility with the updated `asString` method.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->