### PR TITLE
fix: withLogger

### DIFF
--- a/src/event-store-options.ts
+++ b/src/event-store-options.ts
@@ -4,6 +4,7 @@ import {
   Event,
   EventSerializer,
   KeyResolver,
+  Logger,
   SnapshotSerializer,
 } from "./types";
 import moment from "moment";
@@ -23,6 +24,8 @@ interface EventStoreOptions<
   withEventSerializer(eventSerializer: EventSerializer<AID, E>): This;
 
   withSnapshotSerializer(snapshotSerializer: SnapshotSerializer<AID, A>): This;
+
+  withLogger(logger: Logger): This;
 }
 
 export { EventStoreOptions };

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -4,6 +4,7 @@ import {
   Event,
   EventSerializer,
   KeyResolver,
+  Logger,
   SnapshotSerializer,
 } from "./types";
 import { EventStoreForDynamoDB } from "./internal/event-store-for-dynamodb";
@@ -56,6 +57,7 @@ class EventStoreFactory {
       AID,
       A
     >(),
+    logger: Logger | undefined = undefined,
   ): EventStoreWithOptions<AID, A, E> {
     return new EventStoreForDynamoDB<AID, A, E>(
       dynamodbClient,
@@ -71,6 +73,7 @@ class EventStoreFactory {
       keyResolver,
       eventSerializer,
       snapshotSerializer,
+      logger,
     );
   }
   static ofMemory<

--- a/src/internal/event-store-for-dynamodb.ts
+++ b/src/internal/event-store-for-dynamodb.ts
@@ -209,6 +209,7 @@ class EventStoreForDynamoDB<
       this.keyResolver,
       this.eventSerializer,
       this.snapshotSerializer,
+      this.logger,
     );
   }
 
@@ -229,6 +230,7 @@ class EventStoreForDynamoDB<
       this.keyResolver,
       eventSerializer,
       this.snapshotSerializer,
+      this.logger,
     );
   }
 
@@ -249,6 +251,7 @@ class EventStoreForDynamoDB<
       this.keyResolver,
       this.eventSerializer,
       this.snapshotSerializer,
+      this.logger,
     );
   }
 
@@ -269,6 +272,7 @@ class EventStoreForDynamoDB<
       keyResolver,
       this.eventSerializer,
       this.snapshotSerializer,
+      this.logger,
     );
   }
 
@@ -289,6 +293,26 @@ class EventStoreForDynamoDB<
       this.keyResolver,
       this.eventSerializer,
       snapshotSerializer,
+      this.logger,
+    );
+  }
+
+  withLogger(logger: Logger): EventStoreWithOptions<AID, A, E> {
+    return new EventStoreForDynamoDB(
+      this.dynamodbClient,
+      this.journalTableName,
+      this.snapshotTableName,
+      this.journalAidIndexName,
+      this.snapshotAidIndexName,
+      this.shardCount,
+      this.eventConverter,
+      this.snapshotConverter,
+      this.keepSnapshotCount,
+      this.deleteTtl,
+      this.keyResolver,
+      this.eventSerializer,
+      this.snapshotSerializer,
+      logger,
     );
   }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a `withLogger` method to the `EventStoreOptions` interface and `EventStoreForDynamoDB` class. This allows users to pass in a custom `Logger` object for better control over logging behavior.
- Refactor: Updated the `EventStoreFactory` class and several methods in the `EventStoreForDynamoDB` class to accept an optional `logger` parameter, enhancing flexibility and customization of logging operations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->