### PR TITLE
chore(ci): add CLAUDE automated PR review workflow

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -1,0 +1,40 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Review pull request
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            このプルリクエストをレビューしてください。
+            特に以下を確認してください：
+            - バグや仕様逸脱
+            - セキュリティ上の懸念
+            - パフォーマンスやリソース使用
+            - fraktor-rs の既存設計、AGENTS.md、.agents/rules との整合性
+
+            具体的な問題がある場合は、可能な限りインラインコメントで指摘してください。
+
+          claude_args: |
+            --model claude-opus-4-7 --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that runs on every PR and is granted `pull-requests: write` plus uses an external action with a repository secret, so misconfiguration could create noisy/incorrect comments or broaden CI permissions exposure.
> 
> **Overview**
> Introduces a new GitHub Actions workflow, `claude_review.yml`, that triggers on PR open/synchronize events and runs `anthropics/claude-code-action@v1` to automatically review the PR.
> 
> The job checks out the repo, uses `ANTHROPIC_API_KEY`, and is configured to post PR feedback (including inline comments) with elevated permissions (`pull-requests: write`) and restricted `gh` CLI tooling via `claude_args`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd635151fa797fde34a4ff300b4e08aa72e04b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->