### PR TITLE
chore(ci): update CLAUDE review workflow with detailed PR review API …

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -33,8 +33,28 @@ jobs:
             - セキュリティ上の懸念
             - パフォーマンスやリソース使用
             - fraktor-rs の既存設計、AGENTS.md、.agents/rules との整合性
+            
+            レビューは必ずPull Request Review として実施してください。具体的には以下の手順で行ってください：
 
-            具体的な問題がある場合は、可能な限りインラインコメントで指摘してください。
+            1. `gh api` コマンドを使用して、指摘場所（path, lineを指定）にreviewsをPOSTする。
+            2. `gh pr review` コマンドの `--comment` で数行のサマリー文章を送信する（`--approve` や `--request-changes` は使わず `--comment` を使ってください）
+
+            単なるIssue Commentではなく、必ずPull Request Review APIを使用してレビューを実施してください。
+
+            Pull Request Review APIのサンプルコードは以下の通りです。
+            ```
+            gh api \
+              --method POST \
+              --header "Accept: application/vnd.github+json" \
+              /repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews \
+              --field event="COMMENT" \
+              --field comments[0][path]="main.go" \
+              --field comments[0][line]=10 \
+              --field comments[0][body]="```suggestion
+            func improvedFunction() {
+                return \"better implementation\"
+            }
+            ```
 
           claude_args: |
             --model claude-opus-4-7 --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
…usage instructions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes CI workflow instructions (prompt text) and does not affect application runtime behavior; the main risk is the action posting reviews incorrectly if the instructions/tools don’t match permissions.
> 
> **Overview**
> Updates `.github/workflows/claude_review.yml` to **explicitly require Claude to leave feedback as a GitHub Pull Request Review** rather than an issue comment.
> 
> The prompt now prescribes using `gh api` to post inline review comments (path/line) and `gh pr review --comment` to submit a short summary, and includes a concrete sample `gh api` payload for review creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6554fdc5dcbc8de301ad02ba2d668c3168f8386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プルリクエストレビューワークフローの実装を改善しました。Pull Request Review APIの使用方法に関する手順が更新されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/event-store-adapter-js/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->