### PR TITLE
chore(ci): enhance CLAUDE review workflow with additional triggers an…

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -2,27 +2,24 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
 jobs:
   review:
+    if: ${{ github.event.sender.type != 'Bot' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      issues: write
       pull-requests: write
-      id-token: write
-      actions: read
+      contents: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: PR Agent action step
+        uses: the-pr-agent/pr-agent@main
         with:
-          fetch-depth: 1
-
-      - name: Review pull request
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
-          prompt: "/review REPO: ${{ github.repository }} PR NUMBER: ${{ github.event.pull_request.number }}"
-          claude_args: |
-            --model claude-opus-4-7 --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config.model: "anthropic/claude-opus-4-7"
+          config.fallback_models: '["anthropic/claude-haiku-4-5"]'
+          ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_KEY }}
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "true"


### PR DESCRIPTION
…d configuration updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/workflow-only changes, but it alters when automation runs and grants broader repo permissions which could affect GitHub Action behavior.
> 
> **Overview**
> Switches the `Claude PR Review` GitHub Action from `anthropics/claude-code-action` to `the-pr-agent/pr-agent` and updates configuration to use Anthropic models with fallback.
> 
> Expands triggers to include `ready_for_review` and `issue_comment`, adds a non-bot guard, and adjusts permissions to allow writing `issues`, `pull-requests`, and `contents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96da7b178e767fceababd83065dcd0758d39a12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->