### PR TITLE
[codex] Refine PR workflow gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,131 @@
 name: CI
+
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  lint:
+  changes:
+    name: Detect CI-relevant changes
     runs-on: ubuntu-latest
-    name: "Run lint"
+    outputs:
+      run_code_checks: ${{ steps.filter.outputs.run_code_checks }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
-      with:
-        run_install: false
-    - uses: actions/setup-node@v6
-      with:
-        node-version: 24.x
-        cache: 'pnpm'
-    - run: corepack enable
-    - run: pnpm install --frozen-lockfile
-    - run: pnpm run lint
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect changed paths
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "schedule" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            base="${BASE_SHA}"
+            head="${HEAD_SHA}"
+          else
+            base="${BEFORE_SHA}"
+            head="${HEAD_SHA}"
+          fi
+
+          if [[ -z "${base}" ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${base}" =~ ^0{40}$ ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          changed_entries="$(git diff --name-status -M "${base}" "${head}")"
+          if [[ -z "${changed_entries}" ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          is_docs_only_path() {
+            local path="$1"
+            [[ "${path}" == *.md \
+              || "${path}" == *.rst \
+              || "${path}" == *.txt \
+              || "${path}" == docs/* \
+              || "${path}" == README* \
+              || "${path}" == CHANGELOG* \
+              || "${path}" == LICENSE* ]]
+          }
+
+          run_code_checks=false
+          while IFS=$'\t' read -r status path_a path_b; do
+            paths=("${path_a}")
+            case "${status}" in
+              R* | C*)
+                paths=("${path_a}" "${path_b}")
+                ;;
+            esac
+
+            for path in "${paths[@]}"; do
+              if ! is_docs_only_path "${path}"; then
+                run_code_checks=true
+                break 2
+              fi
+            done
+          done <<< "${changed_entries}"
+
+          echo "run_code_checks=${run_code_checks}" >> "${GITHUB_OUTPUT}"
+
+  lint:
+    name: Run lint
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: pnpm
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run lint
+        run: pnpm run lint
+
   test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - changes
+      - lint
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -32,25 +135,179 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
-      with:
-        run_install: false
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    - run: corepack enable
-    - run: pnpm install --frozen-lockfile
-    - run: pnpm run build
-    - run: pnpm --filter event-store-adapter-js run coverage --runInBand
-    - name: Verify coverage file exists
-      run: test -f "${GITHUB_WORKSPACE}/packages/library/coverage/lcov.info"
-    - name: Upload coverage to Codecov
-      if: success()
-      uses: codecov/codecov-action@v6
-      with:
-        files: ./packages/library/coverage/lcov.info
-        use_oidc: true
-        fail_ci_if_error: true
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
+      - name: Generate coverage
+        run: pnpm --filter event-store-adapter-js run coverage --runInBand
+      - name: Verify coverage file exists
+        run: test -f "${GITHUB_WORKSPACE}/packages/library/coverage/lcov.info"
+      - name: Upload coverage to Codecov
+        if: success()
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          files: ./packages/library/coverage/lcov.info
+          use_oidc: true
+          fail_ci_if_error: true
+
+  codecov-status:
+    name: Codecov Status
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - test
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.run_code_checks == 'true' }}
+    permissions:
+      contents: read
+      checks: read
+      statuses: read
+    steps:
+      - name: Wait for Codecov status checks
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          COVERAGE_RESULT: ${{ needs.test.result }}
+          CODECOV_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+        with:
+          script: |
+            const coverageResult = process.env.COVERAGE_RESULT;
+            if (coverageResult !== "success") {
+              throw new Error(`coverage failed or was skipped: ${coverageResult}`);
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = process.env.CODECOV_SHA;
+            const requiredChecks = ["codecov/project"];
+
+            if (process.env.IS_PULL_REQUEST === "true") {
+              requiredChecks.push("codecov/patch");
+            } else {
+              core.info("Skipping codecov/patch outside pull_request events");
+            }
+
+            for (const checkName of requiredChecks) {
+              await waitForCheck(checkName);
+            }
+
+            async function waitForCheck(checkName) {
+              for (let attempt = 1; attempt <= 60; attempt += 1) {
+                const run = await latestCheckRun(checkName);
+
+                if (run) {
+                  core.info(`${checkName}: status=${run.status} conclusion=${run.conclusion || ""} url=${run.html_url}`);
+
+                  if (run.status === "completed") {
+                    if (run.conclusion === "success") {
+                      return;
+                    }
+
+                    throw new Error(`${checkName} failed with conclusion=${run.conclusion}`);
+                  }
+                } else {
+                  const status = await latestCommitStatus(checkName);
+                  if (status) {
+                    core.info(`${checkName}: state=${status.state} url=${status.target_url || ""}`);
+
+                    if (status.state === "success") {
+                      return;
+                    }
+                    if (status.state === "failure" || status.state === "error") {
+                      throw new Error(`${checkName} failed with state=${status.state}`);
+                    }
+                  } else {
+                    core.info(`${checkName}: waiting for Codecov status (${attempt}/60)`);
+                  }
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, 10000));
+              }
+
+              core.warning(`${checkName} did not report within timeout; coverage upload already succeeded`);
+            }
+
+            async function latestCheckRun(checkName) {
+              const response = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref,
+                check_name: checkName,
+                per_page: 100,
+              });
+              return response.data.check_runs
+                .filter((checkRun) => checkRun.name === checkName)
+                .sort((left, right) => {
+                  const rightTime = Date.parse(right.started_at || right.created_at);
+                  const leftTime = Date.parse(left.started_at || left.created_at);
+                  return rightTime - leftTime;
+                })[0];
+            }
+
+            async function latestCommitStatus(checkName) {
+              const response = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref });
+              return response.data.statuses.find((status) => status.context === checkName);
+            }
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - lint
+      - test
+      - codecov-status
+    if: always()
+    steps:
+      - name: All checks passed
+        env:
+          RUN_CODE_CHECKS: ${{ needs.changes.outputs.run_code_checks }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "changes failed"
+            exit 1
+          fi
+
+          run_code_checks="${RUN_CODE_CHECKS}"
+          case "${run_code_checks}" in
+            true)
+              expected_code_job_result="success"
+              ;;
+            false)
+              expected_code_job_result="skipped"
+              ;;
+            *)
+              echo "changes did not report valid run_code_checks: ${run_code_checks}"
+              exit 1
+              ;;
+          esac
+
+          require_result() {
+            local name="$1"
+            local actual="$2"
+            local expected="$3"
+            if [[ "${actual}" != "${expected}" ]]; then
+              echo "${name} was ${actual}; expected ${expected}"
+              exit 1
+            fi
+          }
+
+          require_result "lint" "${{ needs.lint.result }}" "${expected_code_job_result}"
+          require_result "test" "${{ needs.test.result }}" "${expected_code_job_result}"
+          require_result "codecov-status" "${{ needs['codecov-status'].result }}" "${expected_code_job_result}"
+          echo "All CI checks passed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
   changes:
     name: Detect CI-relevant changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       run_code_checks: ${{ steps.filter.outputs.run_code_checks }}
     steps:
@@ -26,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Detect changed paths
         id: filter
         env:
@@ -42,7 +45,7 @@ jobs:
           fi
 
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            base="${BASE_SHA}"
+            base="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")"
             head="${HEAD_SHA}"
           else
             base="${BEFORE_SHA}"
@@ -98,12 +101,16 @@ jobs:
   lint:
     name: Run lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - changes
     if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -167,7 +174,7 @@ jobs:
   codecov-status:
     name: Codecov Status
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs:
       - changes
       - test
@@ -231,7 +238,7 @@ jobs:
                       throw new Error(`${checkName} failed with state=${status.state}`);
                     }
                   } else {
-                    core.info(`${checkName}: waiting for Codecov status (${attempt}/60)`);
+                    core.info(`${checkName}: waiting for Codecov status (${attempt}/90)`);
                   }
                 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
   codecov-status:
     name: Codecov Status
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - changes
       - test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
                 await new Promise((resolve) => setTimeout(resolve, 10000));
               }
 
-              core.warning(`${checkName} did not report within timeout; coverage upload already succeeded`);
+              throw new Error(`${checkName} did not report within timeout`);
             }
 
             async function latestCheckRun(checkName) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
   codecov-status:
     name: Codecov Status
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs:
       - changes
       - test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
   codecov-status:
     name: Codecov Status
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs:
       - changes
       - test
@@ -206,7 +206,7 @@ jobs:
             }
 
             async function waitForCheck(checkName) {
-              for (let attempt = 1; attempt <= 60; attempt += 1) {
+              for (let attempt = 1; attempt <= 90; attempt += 1) {
                 const run = await latestCheckRun(checkName);
 
                 if (run) {

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -8,25 +8,151 @@ on:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:
     types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
 
 permissions:
+  checks: read
   contents: read
+  issues: read
   pull-requests: read
 
+concurrency:
+  group: review-thread-resolution-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
-  unresolved-review-threads:
-    name: Check unresolved review threads
-    if: ${{ github.event.pull_request != null && github.event.pull_request.base != null && github.event.pull_request.base.ref == 'main' }}
+  unresolved-comments:
+    name: Check unresolved comments
+    if: ${{ github.event.pull_request != null || github.event.issue.pull_request != null }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - name: Check unresolved review threads
+      - name: Check unresolved comments
         env:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           set -euo pipefail
+
+          pr_response="$(
+            gh api graphql \
+              -F owner="$OWNER" \
+              -F name="$REPO" \
+              -F number="$PR_NUMBER" \
+              -f query='
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      author {
+                        __typename
+                        login
+                      }
+                      baseRefName
+                      headRefOid
+                    }
+                  }
+                }
+              '
+          )"
+
+          if jq -e '.errors? | length > 0' <<< "$pr_response" > /dev/null; then
+            echo "::error::GitHub GraphQL returned errors while fetching PR metadata."
+            jq -r '.errors[]?.message' <<< "$pr_response" >&2
+            exit 1
+          fi
+
+          if ! jq -e '.data.repository.pullRequest.author.login
+            and .data.repository.pullRequest.baseRefName' \
+            <<< "$pr_response" > /dev/null; then
+            echo "::error::GitHub GraphQL response did not include PR metadata."
+            jq -c '.' <<< "$pr_response" >&2
+            exit 1
+          fi
+
+          pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
+          pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
+          base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
+          head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
+
+          if [[ "$base_ref" != "main" ]]; then
+            echo "Skipping PR #$PR_NUMBER because base branch is $base_ref, not main."
+            exit 0
+          fi
+
+          max_attempts=60
+          initial_sleep_seconds=5
+          max_sleep_seconds=30
+          sleep_seconds="$initial_sleep_seconds"
+          attempt=0
+          while [[ "$attempt" -lt "$max_attempts" ]]; do
+            attempt=$((attempt + 1))
+            status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)" || {
+              if [[ "$attempt" -eq "$max_attempts" ]]; then
+                echo "::error::Failed to fetch PR status after $max_attempts attempts."
+                exit 1
+              fi
+              echo "::warning::Failed to fetch PR status on attempt $attempt; retrying."
+              sleep "$sleep_seconds"
+              if [[ "$sleep_seconds" -lt "$max_sleep_seconds" ]]; then
+                sleep_seconds=$((sleep_seconds * 2))
+                if [[ "$sleep_seconds" -gt "$max_sleep_seconds" ]]; then
+                  sleep_seconds="$max_sleep_seconds"
+                fi
+              fi
+              continue
+            }
+            current_head_ref_oid="$(jq -r '.headRefOid' <<< "$status_response")"
+            if [[ "$current_head_ref_oid" != "$head_ref_oid" ]]; then
+              echo "::error::PR head changed from $head_ref_oid to $current_head_ref_oid while waiting for checks."
+              exit 1
+            fi
+
+            pending_checks="$(
+              jq -r '
+                .statusCheckRollup[]
+                | select(
+                    if .__typename == "CheckRun" then
+                      (.name != "Check unresolved comments"
+                        and .workflowName != "Review Thread Resolution"
+                        and (.status != "COMPLETED"))
+                    elif .__typename == "StatusContext" then
+                      (.state == "PENDING" or .state == "EXPECTED")
+                    else
+                      false
+                    end
+                  )
+                | if .__typename == "CheckRun" then
+                    "\(.workflowName // "unknown") / \(.name // "unknown")"
+                  else
+                    "\(.context // "unknown")"
+                  end
+              ' <<< "$status_response"
+            )"
+
+            if [[ -z "$pending_checks" ]]; then
+              echo "All other PR checks have reached a terminal state."
+              break
+            fi
+
+            if [[ "$attempt" -eq "$max_attempts" ]]; then
+              echo "::error::Timed out waiting for other PR checks to finish before evaluating review comments."
+              echo "$pending_checks" >&2
+              exit 1
+            fi
+
+            echo "Waiting for other PR checks to finish before evaluating review comments:"
+            echo "$pending_checks"
+            sleep "$sleep_seconds"
+            if [[ "$sleep_seconds" -lt "$max_sleep_seconds" ]]; then
+              sleep_seconds=$((sleep_seconds * 2))
+              if [[ "$sleep_seconds" -gt "$max_sleep_seconds" ]]; then
+                sleep_seconds="$max_sleep_seconds"
+              fi
+            fi
+          done
 
           unresolved='[]'
           cursor=''
@@ -107,15 +233,129 @@ jobs:
           unresolved_count="$(jq 'length' <<< "$unresolved")"
           if [[ "$unresolved_count" -eq 0 ]]; then
             echo "No unresolved PR review threads."
-            exit 0
+          fi
+
+          top_level_comments='[]'
+          cursor=''
+          page=1
+
+          while :; do
+            cursor_args=()
+            if [[ -n "$cursor" ]]; then
+              cursor_args=(-F cursor="$cursor")
+            fi
+
+            response="$(
+              gh api graphql \
+                -F owner="$OWNER" \
+                -F name="$REPO" \
+                -F number="$PR_NUMBER" \
+                "${cursor_args[@]}" \
+                -f query='
+                  query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequest(number: $number) {
+                        comments(first: 100, after: $cursor) {
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                          nodes {
+                            url
+                            createdAt
+                            updatedAt
+                            authorAssociation
+                            author {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                '
+            )"
+
+            if jq -e '.errors? | length > 0' <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL returned errors while fetching top-level PR comments on page $page."
+              jq -r '.errors[]?.message' <<< "$response" >&2
+              exit 1
+            fi
+
+            if ! jq -e '.data.repository.pullRequest.comments.nodes
+              and .data.repository.pullRequest.comments.pageInfo' \
+              <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL response did not include top-level PR comments on page $page."
+              jq -c '.' <<< "$response" >&2
+              exit 1
+            fi
+
+            page_comments="$(jq -c '.data.repository.pullRequest.comments.nodes' <<< "$response")"
+            top_level_comments="$(
+              jq -c -n --argjson current "$top_level_comments" --argjson page "$page_comments" \
+                '$current + $page'
+            )"
+
+            has_next="$(jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage' <<< "$response")"
+            if [[ "$has_next" != "true" ]]; then
+              break
+            fi
+            cursor="$(jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor' <<< "$response")"
+            page=$((page + 1))
+          done
+
+          unacknowledged_top_level="$(
+            jq -c --arg pr_author "$pr_author" --arg pr_author_type "$pr_author_type" '
+              . as $comments
+              | [
+                  $comments[]
+                  | select((.author.login // "") != $pr_author)
+                  | . as $comment
+                  | select([
+                      $comments[]
+                      # Human-authored PRs require the PR author to acknowledge.
+                      # Bot-authored PRs allow maintainers to acknowledge on behalf of the bot.
+                      | select(
+                          (.author.login // "") == $pr_author
+                          or (
+                            $pr_author_type == "Bot"
+                            and (
+                              .authorAssociation == "OWNER"
+                              or .authorAssociation == "MEMBER"
+                              or .authorAssociation == "COLLABORATOR"
+                            )
+                          )
+                        )
+                      | select(.createdAt > ($comment.updatedAt // $comment.createdAt))
+                    ] | length == 0)
+                ]
+            ' <<< "$top_level_comments"
+          )"
+
+          unacknowledged_top_level_count="$(jq 'length' <<< "$unacknowledged_top_level")"
+          if [[ "$unacknowledged_top_level_count" -eq 0 ]]; then
+            echo "No unacknowledged top-level PR comments."
           fi
 
           {
-            echo "### Unresolved PR review threads"
-            echo
-            jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
-              <<< "$unresolved"
+            if [[ "$unresolved_count" -gt 0 ]]; then
+              echo "### Unresolved PR review threads"
+              echo
+              jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
+                <<< "$unresolved"
+              echo
+            fi
+            if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
+              echo "### Unacknowledged top-level PR comments"
+              echo
+              jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
+                <<< "$unacknowledged_top_level"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "::error::$unresolved_count unresolved PR review thread(s) remain. Resolve all review conversations before merging."
+          if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
+            exit 0
+          fi
+
+          echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain. Resolve or acknowledge all review conversations before merging."
           exit 1

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -33,7 +33,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -353,9 +353,9 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
-            exit 0
+          if [[ "$unresolved_count" -gt 0 || "$unacknowledged_top_level_count" -gt 0 ]]; then
+            echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain. Resolve or acknowledge all review conversations before merging."
+            exit 1
           fi
 
-          echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain. Resolve or acknowledge all review conversations before merging."
-          exit 1
+          exit 0

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ -z "${PR_NUMBER:-}" ]]; then
+            echo "::error::PR_NUMBER is empty."
+            exit 1
+          fi
+
           pr_response="$(
             gh api graphql \
               -F owner="$OWNER" \

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -309,12 +309,102 @@ jobs:
             page=$((page + 1))
           done
 
+          cursor=''
+          page=1
+
+          while :; do
+            cursor_args=()
+            if [[ -n "$cursor" ]]; then
+              cursor_args=(-F cursor="$cursor")
+            fi
+
+            response="$(
+              gh api graphql \
+                -F owner="$OWNER" \
+                -F name="$REPO" \
+                -F number="$PR_NUMBER" \
+                "${cursor_args[@]}" \
+                -f query='
+                  query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequest(number: $number) {
+                        reviews(first: 100, after: $cursor) {
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                          nodes {
+                            url
+                            body
+                            state
+                            submittedAt
+                            updatedAt
+                            authorAssociation
+                            author {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                '
+            )"
+
+            if jq -e '.errors? | length > 0' <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL returned errors while fetching PR reviews on page $page."
+              jq -r '.errors[]?.message' <<< "$response" >&2
+              exit 1
+            fi
+
+            if ! jq -e '.data.repository.pullRequest.reviews.nodes
+              and .data.repository.pullRequest.reviews.pageInfo' \
+              <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL response did not include PR review data on page $page."
+              jq -c '.' <<< "$response" >&2
+              exit 1
+            fi
+
+            page_review_comments="$(
+              jq -c '.data.repository.pullRequest.reviews.nodes
+                | map(select((.body // "") != "" and .state != "DISMISSED"))
+                | map({
+                    url,
+                    createdAt: .submittedAt,
+                    updatedAt: (.updatedAt // .submittedAt),
+                    authorAssociation,
+                    author
+                  })' <<< "$response"
+            )"
+            top_level_comments="$(
+              jq -c -n --argjson current "$top_level_comments" --argjson page "$page_review_comments" \
+                '$current + $page'
+            )"
+
+            has_next="$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage' <<< "$response")"
+            if [[ "$has_next" != "true" ]]; then
+              break
+            fi
+            cursor="$(jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor' <<< "$response")"
+            page=$((page + 1))
+          done
+
           unacknowledged_top_level="$(
             jq -c --arg pr_author "$pr_author" --arg pr_author_type "$pr_author_type" '
               . as $comments
               | [
                   $comments[]
-                  | select((.author.login // "") != $pr_author)
+                  | select(
+                      ((.author.login // "") != $pr_author)
+                      and (
+                        $pr_author_type != "Bot"
+                        or (
+                          .authorAssociation != "OWNER"
+                          and .authorAssociation != "MEMBER"
+                          and .authorAssociation != "COLLABORATOR"
+                        )
+                      )
+                    )
                   | . as $comment
                   | select([
                       $comments[]
@@ -339,7 +429,7 @@ jobs:
 
           unacknowledged_top_level_count="$(jq 'length' <<< "$unacknowledged_top_level")"
           if [[ "$unacknowledged_top_level_count" -eq 0 ]]; then
-            echo "No unacknowledged top-level PR comments."
+            echo "No unacknowledged top-level PR comments or review summaries."
           fi
 
           {
@@ -351,7 +441,7 @@ jobs:
               echo
             fi
             if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
-              echo "### Unacknowledged top-level PR comments"
+              echo "### Unacknowledged top-level PR comments or review summaries"
               echo
               jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
                 <<< "$unacknowledged_top_level"
@@ -359,7 +449,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$unresolved_count" -gt 0 || "$unacknowledged_top_level_count" -gt 0 ]]; then
-            echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain. Resolve or acknowledge all review conversations before merging."
+            echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) or review summary comment(s) remain. Resolve or acknowledge all review conversations before merging."
             exit 1
           fi
 

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   unresolved-comments:
     name: Check unresolved comments
-    if: ${{ github.event.pull_request != null || github.event.issue.pull_request != null }}
+    if: ${{ github.event.pull_request != null || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
### **User description**
## Summary
- Import the stronger review-thread resolution flow from fraktor-rs, including top-level PR comment acknowledgement checks and waiting for other checks before evaluation.
- Refine CI with docs-only change detection, manual/scheduled runs, concurrency, Codecov status propagation, and a final CI Success gate.
- Keep the existing pnpm/Node build, lint, coverage, and Codecov upload behavior aligned with this repository.

## Validation
- `/usr/bin/ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/ci.yml .github/workflows/review-thread-resolution.yml`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/review-thread-resolution.yml`

## Notes
- `actionlint` is not installed locally, so it was not run.
- `.vscode/settings.json` has pre-existing local changes and is intentionally excluded from this PR.


___

### **PR Type**
Enhancement


___

### **Description**
- Add docs-only change detection to skip CI for documentation-only PRs

- Implement Codecov status polling with timeout and failure handling

- Enhance review thread resolution with top-level comment acknowledgement checks

- Add concurrency controls, scheduled runs, and comprehensive workflow gates

- Refine workflow conditions and add explicit event guards for clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR/Push/Schedule"] -->|triggers| B["changes job"]
  B -->|docs-only?| C["skip code checks"]
  B -->|code changes| D["lint job"]
  B -->|code changes| E["test job"]
  E -->|coverage generated| F["codecov-status job"]
  F -->|polls Codecov| G["validates checks"]
  D --> H["ci-success gate"]
  E --> H
  F --> H
  H -->|all passed| I["CI Success"]
  A -->|PR event| J["review-thread-resolution"]
  J -->|wait for checks| K["validate threads"]
  K -->|check comments| L["verify acknowledgement"]
  L -->|all resolved| M["Review Gate Pass"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Refine CI workflow with change detection and Codecov gates</code></dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>changes</code> job to detect CI-relevant changes and skip code checks <br>for docs-only PRs<br> <li> Added <code>schedule</code> and <code>workflow_dispatch</code> event triggers with concurrency <br>configuration<br> <li> Added <code>codecov-status</code> job to poll and validate Codecov check results <br>with 45-minute timeout<br> <li> Added <code>ci-success</code> final gate job that validates all upstream jobs <br>completed as expected<br> <li> Enhanced all jobs with explicit step names, improved formatting, and <br>conditional execution based on change detection</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/event-store-adapter-js/pull/926/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+302/-37</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>review-thread-resolution.yml</strong><dd><code>Enhance review workflow with acknowledgement checks and polling</code></dd></summary>
<hr>

.github/workflows/review-thread-resolution.yml

<ul><li>Added <code>issue_comment</code> event trigger to handle top-level PR comments<br> <li> Added PR metadata validation including base branch and head ref <br>verification<br> <li> Implemented polling mechanism to wait for other PR checks before <br>evaluating review threads<br> <li> Added top-level comment and review acknowledgement detection with <br>author-aware logic<br> <li> Enhanced error handling with detailed validation and timeout <br>management (45-minute limit)<br> <li> Renamed job from <code>unresolved-review-threads</code> to <code>unacknowledged-comments</code> <br>with expanded scope</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/event-store-adapter-js/pull/926/files#diff-f4df2572955ee3a7bf2e9a4fba9c4200d03cc100acc603e5fda498333715ef6f">+347/-12</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

