### PR TITLE
[codex] Publish review comment check status on PR head

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -12,8 +12,8 @@ on:
     types: [created, edited, deleted]
 
 permissions:
-  checks: read
   contents: read
+  checks: write
   issues: read
   pull-requests: read
 
@@ -34,6 +34,8 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -56,7 +58,11 @@ jobs:
                         login
                       }
                       baseRefName
+                      headRepository {
+                        nameWithOwner
+                      }
                       headRefOid
+                      url
                     }
                   }
                 }
@@ -70,7 +76,9 @@ jobs:
           fi
 
           if ! jq -e '.data.repository.pullRequest.author.login
-            and .data.repository.pullRequest.baseRefName' \
+            and .data.repository.pullRequest.baseRefName
+            and .data.repository.pullRequest.headRefOid
+            and .data.repository.pullRequest.url' \
             <<< "$pr_response" > /dev/null; then
             echo "::error::GitHub GraphQL response did not include PR metadata."
             jq -c '.' <<< "$pr_response" >&2
@@ -80,7 +88,142 @@ jobs:
           pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
           pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
           base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
+          head_repository="$(jq -r '.data.repository.pullRequest.headRepository.nameWithOwner // ""' <<< "$pr_response")"
           head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
+          pr_url="$(jq -r '.data.repository.pullRequest.url' <<< "$pr_response")"
+
+          should_publish_head_check() {
+            if [[ "$EVENT_NAME" != "issue_comment" ]]; then
+              return 1
+            fi
+
+            if [[ -z "$head_repository" ]]; then
+              echo "::warning::Skipping synthetic check-run publication because PR head repository metadata is unavailable." >&2
+              return 1
+            fi
+
+            if [[ "$head_repository" != "$OWNER/$REPO" ]]; then
+              echo "::notice::Skipping synthetic check-run publication for fork PR head ($head_repository)." >&2
+              return 1
+            fi
+
+            if [[ "$pr_author" == "dependabot[bot]" ]]; then
+              echo "::warning::Skipping synthetic check-run publication for Dependabot PR author." >&2
+              return 1
+            fi
+
+            return 0
+          }
+
+          publish_head_check() {
+            local conclusion="$1"
+            local summary="$2"
+            local check_summary="$summary"
+            local max_summary_chars=60000
+            local truncation_suffix
+            local available_chars
+            local request_payload
+            local check_run_response
+            local check_run_error
+            local check_run_url
+
+            if (( ${#check_summary} > max_summary_chars )); then
+              truncation_suffix=$'\n\n... truncated for GitHub Checks API summary limit ...'
+              available_chars=$(( max_summary_chars - ${#truncation_suffix} ))
+              if (( available_chars < 1 )); then
+                check_summary="${truncation_suffix:0:max_summary_chars}"
+              else
+                check_summary="${check_summary:0:available_chars}${truncation_suffix}"
+              fi
+            fi
+
+            request_payload="$(
+              jq -n \
+                --arg name "Check unresolved comments" \
+                --arg head_sha "$head_ref_oid" \
+                --arg conclusion "$conclusion" \
+                --arg details_url "$RUN_URL" \
+                --arg title "Review Thread Resolution" \
+                --arg summary "$check_summary" \
+                '{
+                  name: $name,
+                  head_sha: $head_sha,
+                  status: "completed",
+                  conclusion: $conclusion,
+                  details_url: $details_url,
+                  output: {
+                    title: $title,
+                    summary: $summary
+                  }
+                }'
+            )"
+
+            check_run_error="$(mktemp)"
+            trap 'rm -f "$check_run_error"; trap - RETURN' RETURN
+            if ! check_run_response="$(
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "repos/$OWNER/$REPO/check-runs" \
+                --input - \
+                2> "$check_run_error" <<< "$request_payload"
+            )"; then
+              echo "::error::Failed to create check run via GitHub API."
+              cat "$check_run_error" >&2
+              return 1
+            fi
+            if [[ -s "$check_run_error" ]]; then
+              cat "$check_run_error" >&2
+            fi
+
+            if jq -e '(.errors? // []) | length > 0' <<< "$check_run_response" > /dev/null; then
+              echo "::error::GitHub API returned errors while creating check run."
+              jq -r '.errors[]?.message // empty' <<< "$check_run_response" >&2
+              return 1
+            fi
+            if jq -e '.message? // empty' <<< "$check_run_response" > /dev/null; then
+              echo "::error::GitHub API returned an error message while creating check run."
+              jq -r '.message' <<< "$check_run_response" >&2
+              return 1
+            fi
+            if ! jq -e '.id and (.html_url // .url)' <<< "$check_run_response" > /dev/null; then
+              echo "::error::GitHub API response did not include check-run metadata."
+              jq -c '.' <<< "$check_run_response" >&2
+              return 1
+            fi
+
+            check_run_url="$(jq -r '.html_url // .url' <<< "$check_run_response")"
+            echo "Published check run: $check_run_url"
+          }
+
+          build_summary() {
+            local unresolved_count="$1"
+            local unacknowledged_top_level_count="$2"
+            local unresolved="$3"
+            local unacknowledged_top_level="$4"
+            local summary_pr_url="$5"
+
+            {
+              echo "PR: $summary_pr_url"
+              echo
+              echo "$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) or review summary comment(s) remain."
+              echo
+              if [[ "$unresolved_count" -gt 0 ]]; then
+                echo "### Unresolved PR review threads"
+                echo
+                jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
+                  <<< "$unresolved"
+                echo
+              fi
+              if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
+                echo "### Unacknowledged top-level PR comments or review summaries"
+                echo
+                jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
+                  <<< "$unacknowledged_top_level"
+              fi
+            }
+          }
 
           if [[ "$base_ref" != "main" ]]; then
             echo "Skipping PR #$PR_NUMBER because base branch is $base_ref, not main."
@@ -432,25 +575,27 @@ jobs:
             echo "No unacknowledged top-level PR comments or review summaries."
           fi
 
-          {
-            if [[ "$unresolved_count" -gt 0 ]]; then
-              echo "### Unresolved PR review threads"
-              echo
-              jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
-                <<< "$unresolved"
-              echo
-            fi
-            if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
-              echo "### Unacknowledged top-level PR comments or review summaries"
-              echo
-              jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
-                <<< "$unacknowledged_top_level"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          summary="$(build_summary \
+            "$unresolved_count" \
+            "$unacknowledged_top_level_count" \
+            "$unresolved" \
+            "$unacknowledged_top_level" \
+            "$pr_url")"
+          printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$unresolved_count" -gt 0 || "$unacknowledged_top_level_count" -gt 0 ]]; then
-            echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) or review summary comment(s) remain. Resolve or acknowledge all review conversations before merging."
-            exit 1
+          if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
+            # Top-level PR comments arrive as issue_comment and need a synthetic
+            # head check because that event is not naturally attached to the PR head.
+            if should_publish_head_check; then
+              publish_head_check "success" "$summary"
+            fi
+            exit 0
           fi
 
-          exit 0
+          # Other review events already create their own PR-head workflow check.
+          if should_publish_head_check; then
+            publish_head_check "failure" "$summary"
+          fi
+
+          echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) or review summary comment(s) remain. Resolve or acknowledge all review conversations before merging."
+          exit 1

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -107,11 +107,6 @@ jobs:
               return 1
             fi
 
-            if [[ "$pr_author" == "dependabot[bot]" ]]; then
-              echo "::warning::Skipping synthetic check-run publication for Dependabot PR author." >&2
-              return 1
-            fi
-
             return 0
           }
 
@@ -122,9 +117,11 @@ jobs:
             local max_summary_chars=60000
             local truncation_suffix
             local available_chars
-            local request_payload
+            local create_payload
+            local update_payload
             local check_run_response
             local check_run_error
+            local existing_check_run_id
             local check_run_url
 
             if (( ${#check_summary} > max_summary_chars )); then
@@ -137,7 +134,7 @@ jobs:
               fi
             fi
 
-            request_payload="$(
+            create_payload="$(
               jq -n \
                 --arg name "Check unresolved comments" \
                 --arg head_sha "$head_ref_oid" \
@@ -157,21 +154,70 @@ jobs:
                   }
                 }'
             )"
+            update_payload="$(
+              jq -n \
+                --arg name "Check unresolved comments" \
+                --arg conclusion "$conclusion" \
+                --arg details_url "$RUN_URL" \
+                --arg title "Review Thread Resolution" \
+                --arg summary "$check_summary" \
+                '{
+                  name: $name,
+                  status: "completed",
+                  conclusion: $conclusion,
+                  details_url: $details_url,
+                  output: {
+                    title: $title,
+                    summary: $summary
+                  }
+                }'
+            )"
+
+            existing_check_run_id="$(
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "repos/$OWNER/$REPO/commits/$head_ref_oid/check-runs?check_name=Check%20unresolved%20comments&per_page=100" \
+                --jq '
+                  [
+                    .check_runs[]
+                    | select(.output.title == "Review Thread Resolution")
+                    | .id
+                  ]
+                  | first // empty
+                '
+            )"
 
             check_run_error="$(mktemp)"
             trap 'rm -f "$check_run_error"; trap - RETURN' RETURN
-            if ! check_run_response="$(
-              gh api \
-                --method POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "repos/$OWNER/$REPO/check-runs" \
-                --input - \
-                2> "$check_run_error" <<< "$request_payload"
-            )"; then
-              echo "::error::Failed to create check run via GitHub API."
-              cat "$check_run_error" >&2
-              return 1
+            if [[ -n "$existing_check_run_id" ]]; then
+              if ! check_run_response="$(
+                gh api \
+                  --method PATCH \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "repos/$OWNER/$REPO/check-runs/$existing_check_run_id" \
+                  --input - \
+                  2> "$check_run_error" <<< "$update_payload"
+              )"; then
+                echo "::error::Failed to update check run via GitHub API."
+                cat "$check_run_error" >&2
+                return 1
+              fi
+            else
+              if ! check_run_response="$(
+                gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "repos/$OWNER/$REPO/check-runs" \
+                  --input - \
+                  2> "$check_run_error" <<< "$create_payload"
+              )"; then
+                echo "::error::Failed to create check run via GitHub API."
+                cat "$check_run_error" >&2
+                return 1
+              fi
             fi
             if [[ -s "$check_run_error" ]]; then
               cat "$check_run_error" >&2

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -121,6 +121,27 @@ jobs:
             return 0
           }
 
+          refresh_head_ref_oid() {
+            local latest_head_ref_oid
+
+            latest_head_ref_oid="$(
+              gh pr view "$PR_NUMBER" \
+                --repo "$OWNER/$REPO" \
+                --json headRefOid \
+                --jq '.headRefOid'
+            )"
+
+            if [[ -z "$latest_head_ref_oid" || "$latest_head_ref_oid" == "null" ]]; then
+              echo "::error::Failed to refresh PR head SHA before publishing the synthetic check." >&2
+              return 1
+            fi
+
+            if [[ "$latest_head_ref_oid" != "$head_ref_oid" ]]; then
+              echo "::notice::PR head changed from $head_ref_oid to $latest_head_ref_oid before publishing the synthetic check." >&2
+              head_ref_oid="$latest_head_ref_oid"
+            fi
+          }
+
           publish_head_check() {
             local conclusion="$1"
             local summary="$2"
@@ -636,6 +657,8 @@ jobs:
             "$unacknowledged_top_level" \
             "$pr_url")"
           printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
+
+          refresh_head_ref_oid
 
           if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
             # issue_comment runs may create a synthetic head check. Other events

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -92,11 +92,22 @@ jobs:
           head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
           pr_url="$(jq -r '.data.repository.pullRequest.url' <<< "$pr_response")"
 
-          should_publish_head_check() {
-            if [[ "$EVENT_NAME" != "issue_comment" ]]; then
-              return 1
-            fi
+          find_existing_head_check() {
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/$OWNER/$REPO/commits/$head_ref_oid/check-runs?check_name=Check%20unresolved%20comments&per_page=100" \
+              --jq '
+                [
+                  .check_runs[]
+                  | select(.output.title == "Review Thread Resolution")
+                  | .id
+                ]
+                | first // empty
+              '
+          }
 
+          should_publish_head_check() {
             if [[ -z "$head_repository" ]]; then
               echo "::warning::Skipping synthetic check-run publication because PR head repository metadata is unavailable." >&2
               return 1
@@ -123,6 +134,11 @@ jobs:
             local check_run_error
             local existing_check_run_id
             local check_run_url
+            local create_if_missing="false"
+
+            if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+              create_if_missing="true"
+            fi
 
             if (( ${#check_summary} > max_summary_chars )); then
               truncation_suffix=$'\n\n... truncated for GitHub Checks API summary limit ...'
@@ -173,20 +189,7 @@ jobs:
                 }'
             )"
 
-            existing_check_run_id="$(
-              gh api \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "repos/$OWNER/$REPO/commits/$head_ref_oid/check-runs?check_name=Check%20unresolved%20comments&per_page=100" \
-                --jq '
-                  [
-                    .check_runs[]
-                    | select(.output.title == "Review Thread Resolution")
-                    | .id
-                  ]
-                  | first // empty
-                '
-            )"
+            existing_check_run_id="$(find_existing_head_check)"
 
             check_run_error="$(mktemp)"
             trap 'rm -f "$check_run_error"; trap - RETURN' RETURN
@@ -205,6 +208,11 @@ jobs:
                 return 1
               fi
             else
+              if [[ "$create_if_missing" != "true" ]]; then
+                echo "No existing synthetic check run to update."
+                return 0
+              fi
+
               if ! check_run_response="$(
                 gh api \
                   --method POST \
@@ -630,15 +638,16 @@ jobs:
           printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
-            # Top-level PR comments arrive as issue_comment and need a synthetic
-            # head check because that event is not naturally attached to the PR head.
+            # issue_comment runs may create a synthetic head check. Other events
+            # only update one if it already exists, clearing stale conclusions.
             if should_publish_head_check; then
               publish_head_check "success" "$summary"
             fi
             exit 0
           fi
 
-          # Other review events already create their own PR-head workflow check.
+          # Non-comment events update an existing synthetic check so a previous
+          # issue_comment failure cannot remain stale on the PR head.
           if should_publish_head_check; then
             publish_head_check "failure" "$summary"
           fi


### PR DESCRIPTION
## Summary

- Publish a synthetic `Check unresolved comments` check run on the PR head SHA for `issue_comment` events.
- Include the PR URL and unresolved-comment summary in the synthetic check output.
- Keep the existing workflow behavior for pull request and review-thread events while preserving review summary comment handling.

## Why

Top-level PR comments trigger `issue_comment` workflow runs, but those runs are not reliably associated with the PR head status checks. That can leave the required review-thread check stale until someone manually reruns the workflow. Publishing the result directly to the PR head SHA lets the next top-level comment event update the visible check state.

## Validation

- `yq '.' .github/workflows/review-thread-resolution.yml > /dev/null`
- `bash -n <(yq -r '.jobs."unresolved-comments".steps[0].run' .github/workflows/review-thread-resolution.yml)`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds GitHub Checks API create/update logic (with new `checks: write` permission) to publish statuses directly to the PR head SHA, which could affect required check behavior if misconfigured but is scoped to a single workflow.
> 
> **Overview**
> Ensures the `Review Thread Resolution` workflow publishes a *synthetic* `Check unresolved comments` check-run directly on the PR head SHA so `issue_comment`-triggered runs update the visible/required status on the PR.
> 
> The workflow now fetches extra PR metadata (PR URL, head repo), builds a single summary used both for `GITHUB_STEP_SUMMARY` and check output, refreshes the head SHA before publishing, skips publishing for forks, and updates (or for `issue_comment`, creates) the check-run with `success`/`failure` to avoid stale conclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66a7c33b09b0fcb8b68aa229617fbe27f8d3f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->