### PR TITLE
[codex] Add runtime brand JSON OpenSpec plan for #932

### DIFF
--- a/openspec/changes/replace-interfaces-with-types/design.md
+++ b/openspec/changes/replace-interfaces-with-types/design.md
@@ -111,6 +111,25 @@
 
 代替案として、イベントクラスを残して静的ファクトリ関数だけを使う案がある。この案はクラス識別子を主要なドメインパターンとして教え続けてしまう。
 
+### サンプルのドメイン値は runtime brand と JSON 変換を対で示す
+
+サンプルとライブラリ内テスト用データでは、`UserAccountId`、`UserAccountCreated`、`UserAccountRenamed`、`UserAccount` のようなドメイン値に module-private な `unique symbol` brand を持たせる。brand はプロセス内で `create(...)` を通った値かどうかを判定する補助であり、セキュリティ境界や永続化フォーマットではない。
+
+各同名 factory namespace は、少なくとも次を持つ。
+
+- `create(...)`: 入力を検証し、runtime symbol brand を付与した不変値を返す。
+- `is(value: unknown)`: runtime symbol brand と最低限の shape を確認し、factory 生成値かを判定する。
+- `toJSON(value)`: JSON-safe な plain object へ変換する。
+- `fromJSON(json: unknown)`: JSON-safe shape を検証し、必ず `create(...)` 経由で brand を再付与する。
+
+`fromJSON(...)` だけを追加すると、どの JSON 形状を正とするかが暗黙になるため採用しない。`toJSON(...)` と対で置くことで、serializer converter の利用者に往復可能な形を示す。
+
+JSON 境界では `unique symbol` brand は `JSON.stringify(...)` に出ない。したがって、保存済み payload の判別には `typeName` または既存 default serializer の `{ type, data }` wrapper を使う。`typeName` は JSON 境界の discriminant、runtime symbol brand はプロセス内の factory 生成値判定という役割分担にする。
+
+本来、`toJSON(...)` / `fromJSON(...)` はドメイン層外の adapter / converter 層へ置く方が境界としてはきれいである。ただし、このリポジトリのサンプルでは serializer を作る利用者が実装すべき最低限の形を示すことを優先し、ドメイン例に同居させる。
+
+ライブラリ本体の `EventSerializer` / `SnapshotSerializer` API は変更しない。default serializer は JSON ベースだが、custom serializer でも `deserialize(bytes, converter)` の `converter` が `fromJSON(...)` 相当の parse/factory を呼ぶことで同じ復元パターンを使える。
+
 ## リスク / トレードオフ
 
 - [宣言マージに依存している利用者が拡張点を失う] -> 未リリース API の意図的な破壊的変更として提案とリリースノートに明記する。
@@ -119,5 +138,7 @@
 - [同名の `EventStore` 型 / 値が編集時に紛らわしい] -> `import type` を一貫して使い、構築用オブジェクト型は非公開に保つ。
 - [class からオブジェクトへの書き換えで `this` の挙動が変わる] -> `this` の再束縛に依存するメソッドではなく、クロージャベースの関数とオブジェクトファクトリ補助関数を優先する。
 - [イベント分岐の変更で網羅性チェックが抜ける] -> リテラル `typeName` を持つ判別共用体と `never` による網羅性チェックを使う。
+- [runtime symbol brand が JSON 境界で消える] -> `toJSON(...)` / `fromJSON(...)` を対で提供し、復元時は `fromJSON(...)` が `create(...)` 経由で brand を再付与することをサンプルとドキュメントに明記する。
+- [`toJSON(...)` / `fromJSON(...)` をドメイン例に置くことで層が混ざる] -> 本来は adapter / converter 層が望ましいが、サンプルでは serializer 利用者が実装すべき pattern を示すための割り切りとして扱う。
 - [内部テストが実装クラスを直接構築している可能性がある] -> 可能な限り `EventStore.createX(...)` または内部ファクトリ補助関数経由にし、ストレージ契約テストは維持する。
 - [インメモリストアの初期データから局所的な変更が漏れる] -> 入力境界で防御的コピーを続け、可変状態はクロージャ内に閉じ込める。

--- a/openspec/changes/replace-interfaces-with-types/proposal.md
+++ b/openspec/changes/replace-interfaces-with-types/proposal.md
@@ -12,6 +12,8 @@
 - 外部 SDK 由来のクラスは対象外にする。
 - ライブラリ内テスト用データとサンプルを、クラスを使わない集約 / イベント / 集約 ID モデリングへ更新し、Scala 風の不変値スタイルを示す。
 - サンプルのイベント分岐を `instanceof` ではなく、`typeName` のような判別用データで行う。
+- サンプルとライブラリ内テスト用データに、利用側が serializer converter を実装するときの例として、runtime `unique symbol` brand と同名 factory namespace の `is(...)` / `toJSON(...)` / `fromJSON(...)` を追加する。
+- `fromJSON(...)` だけでなく `toJSON(...)` も対で示し、JSON 境界では brand が消えるため `fromJSON(...)` が必ず `create(...)` 経由で brand を再付与する形にする。
 - 公開ファクトリ関数 / メソッドを、同名ファクトリオブジェクトの `create` メソッドへ揃える。
 - **破壊的変更**: `EventStore.ofDynamoDB(...)`、`EventStore.ofMemory(...)`、`EventStore.ofSpanner(...)` を `EventStore.createDynamoDB(...)`、`EventStore.createMemory(...)`、`EventStore.createSpanner(...)` へ置き換える。
 - **破壊的変更**: `createShardId(...)`、`createShardCount(...)` を `ShardId.create(...)`、`ShardCount.create(...)` へ置き換える。
@@ -35,4 +37,5 @@
 - 公開 API: `Aggregate`、`AggregateId`、`Event`、`EventStore`、入力契約、シリアライザ、ロガー、シャードセレクタは同じ型名でエクスポートし続けるが、該当するものは型エイリアスになる。`AggregateIdValue` はライブラリが集約 ID の具象値を所有しているように見せるため廃止する。
 - ランタイム API: `EventStore.createDynamoDB(...)`、`EventStore.createMemory(...)`、`EventStore.createSpanner(...)`、`ShardId.create(...)`、`ShardCount.create(...)`、`Result.ok(...)`、`Result.err(...)`、`EventStoreError.*(...)`。
 - サンプル / テスト: ドメイン用データはクラスベースの `implements` / `instanceof` パターンから、不変なファクトリ生成値へ移行する。
+- サンプル / テスト: `typeName` は JSON 境界で残る判別用データとして扱い、runtime `unique symbol` brand はプロセス内で factory 生成値を判定する補助として扱う。JSON から復元する converter は `fromJSON(...)` で検証し、`create(...)` 経由で brand を再付与する。
 - ドキュメント: README のサンプルは、ライブラリがクラスを要求していない箇所ではクラスではなく不変オブジェクト値と同名ファクトリオブジェクトを示す。

--- a/openspec/changes/replace-interfaces-with-types/specs/type-based-contracts/spec.md
+++ b/openspec/changes/replace-interfaces-with-types/specs/type-based-contracts/spec.md
@@ -121,6 +121,51 @@
 - **WHEN** イベントがストレージからデシリアライズされ、構造的に互換なイベント値になっている
 - **THEN** サンプルまたはテスト用データのリプレイコードは `event instanceof SomeEventClass` を要求せずに処理できる
 
+### Requirement: サンプルは runtime brand と JSON 復元を示す
+
+サンプルとライブラリ内テスト用データは、利用側が serializer converter を実装するときの pattern として、同名 factory namespace に runtime brand 判定と JSON 変換を持つ。
+
+#### Scenario: factory 生成値は runtime brand で判定できる
+
+- **WHEN** サンプルまたはテスト用データが `UserAccountId.create(...)`、イベント factory、集約 factory で値を構築する
+- **THEN** 生成された値は module-private な `unique symbol` brand を持つ
+- **AND** 同名 factory namespace の `is(value)` はその値を `true` と判定する
+
+#### Scenario: 構造だけを真似た値は branded value として扱わない
+
+- **WHEN** 呼び出し側が `typeName`、`value`、`asString()` などの構造だけを満たす plain object を渡す
+- **THEN** 同名 factory namespace の `is(value)` は runtime symbol brand がないため `false` と判定する
+- **AND** イベントまたは集約 factory は branded `AggregateId` を要求する入力ではその値を拒否する
+
+#### Scenario: JSON 変換は toJSON と fromJSON を対にする
+
+- **WHEN** サンプルまたはテスト用データが集約 ID、イベント、集約を JSON-safe な値に変換する
+- **THEN** 同名 factory namespace は `toJSON(value)` を提供する
+- **AND** `toJSON(value)` の返却値は `typeName` または `{ type, data }` wrapper によって復元先を判別できる
+
+#### Scenario: JSON 復元は brand を再付与する
+
+- **WHEN** サンプルまたはテスト用データが JSON-safe な plain object を復元する
+- **THEN** 同名 factory namespace の `fromJSON(json)` は JSON shape を検証する
+- **AND** `fromJSON(json)` は必ず `create(...)` 経由で runtime symbol brand を再付与した値を返す
+
+#### Scenario: JSON.stringify 後の値は brand を失う
+
+- **WHEN** 呼び出し側が runtime symbol brand を持つサンプル値を `JSON.stringify(...)` し、`JSON.parse(...)` で復元する
+- **THEN** parse 直後の plain object は `is(value)` で `false` と判定される
+- **AND** `fromJSON(...)` を通した後の値は `is(value)` で `true` と判定される
+
+#### Scenario: 既存 converter 名は薄い alias として残る
+
+- **WHEN** 既存サンプルまたはテストが `convertJSONToUserAccountId`、`convertJSONToUserAccountEvent`、`convertJSONToUserAccount` を呼ぶ
+- **THEN** それらの関数は対応する `fromJSON(...)` を呼ぶ薄い alias として利用できる
+
+#### Scenario: ライブラリ serializer API は変更しない
+
+- **WHEN** 呼び出し側が `EventSerializer` または `SnapshotSerializer` を実装する
+- **THEN** ライブラリは既存の `serialize(...)` と `deserialize(bytes, converter)` 契約を維持する
+- **AND** 呼び出し側は `converter` 内で `fromJSON(...)` 相当の parse/factory を呼ぶことで branded domain value を復元できる
+
 ### Requirement: ストア構築は実装形状を隠す
 
 ライブラリは、公開実装クラスではなくファクトリメソッドを通じて EventStore の構築を公開する。

--- a/openspec/changes/replace-interfaces-with-types/tasks.md
+++ b/openspec/changes/replace-interfaces-with-types/tasks.md
@@ -50,3 +50,16 @@
 - [x] 5.11 公開 API オブジェクトと値ファクトリオブジェクトが、サポート対象の使い方では外部からメソッド表を変更できないことをテストで確認する。
 - [x] 5.12 4.0.0 向け移行ガイドに、`EventStore.ofX(...)` から `EventStore.createX(...)`、`createShardId(...)` から `ShardId.create(...)`、ライブラリ提供の `AggregateIdValue` / `createAggregateIdValue(...)` から plain `string` を保持するユーザー側 `UserAccountId.create(...)`、`try/catch` から `Result` 分岐への before / after が含まれていることを確認する。
 - [x] 5.13 `replace-interfaces-with-types` の OpenSpec 状態確認を実行し、change が適用可能なままであることを確認する。
+
+## 6. Runtime brand と JSON 復元導線
+
+- [ ] 6.1 サンプルの `UserAccountId`、`UserAccountCreated`、`UserAccountRenamed`、`UserAccount` に module-private `unique symbol` brand を追加し、`create(...)` が brand 付き不変値を返すようにする。
+- [ ] 6.2 サンプルの同名 factory namespace に `is(value)`、`toJSON(value)`、`fromJSON(json)` を追加し、`fromJSON(...)` は必ず `create(...)` 経由で brand を再付与する。
+- [ ] 6.3 既存の `convertJSONToUserAccountId`、`convertJSONToUserAccountEvent`、`convertJSONToUserAccount` は、対応する `fromJSON(...)` を呼ぶ薄い alias として残す。
+- [ ] 6.4 ライブラリ内テスト用データにも同じ runtime brand / `is` / `toJSON` / `fromJSON` pattern を追加し、DynamoDB / Spanner の deserialize converter が branded value を返すことを確認する。
+- [ ] 6.5 JSON round-trip テストを追加し、`JSON.parse(JSON.stringify(value))` 直後は `is(value) === false`、`fromJSON(...)` 後は `is(value) === true` になることを確認する。
+- [ ] 6.6 構造だけを真似た `AggregateId` plain object が branded ID として受理されないこと、wrong `typeName` / missing `value` / invalid event `type` / invalid `occurredAt` を拒否することをテストする。
+- [ ] 6.7 README / README.ja に `unique symbol` brand、`is`、`toJSON`、`fromJSON` の最小例を追加し、`typeName` は JSON 境界用 discriminant、runtime symbol brand はプロセス内の factory 生成値判定用であることを説明する。
+- [ ] 6.8 `MIGRATION_GUIDE_4.0.md` / `MIGRATION_GUIDE_4.0.ja.md` に、JSON 境界で symbol brand が消えること、deserialize converter は `fromJSON(...)` / factory を通して brand を復元すること、ライブラリ本体は JSON 専用ではないことを追記する。
+- [ ] 6.9 ライブラリの `EventSerializer` / `SnapshotSerializer` 公開 API を変更していないことを確認する。
+- [ ] 6.10 `pnpm --filter event-store-adapter-js run lint`、`pnpm --filter event-store-adapter-js run build`、`pnpm --filter event-store-adapter-js run coverage`、`pnpm --filter @event-store-adapter-js/examples run typecheck` を実行する。


### PR DESCRIPTION
## Summary

- Extend the replace-interfaces-with-types OpenSpec change used by PR #932 with runtime symbol brand guidance.
- Add paired toJSON/fromJSON requirements for sample domain values and internal test fixtures.
- Keep this PR scoped to OpenSpec change artifacts only; no implementation code is included.

## Base

This PR targets `codex/implement-type-based-contract-cleanup` because it is an OpenSpec change update for #932, not a standalone implementation change against `main`.

## Validation

- Verified the branch diff against #932 contains only `openspec/changes/replace-interfaces-with-types` files.
- Ran OpenSpec apply instructions and confirmed the new runtime brand tasks appear as pending work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenSpec requirements only; no runtime or public API code changes in this diff.
> 
> **Overview**
> Extends the **replace-interfaces-with-types** OpenSpec change (for #932) with a planned pattern for sample and internal test domain values: **module-private `unique symbol` runtime brands**, factory namespaces with **`create` / `is` / `toJSON` / `fromJSON`**, and **`fromJSON` always re-branding via `create`**.
> 
> Clarifies that **`typeName`** (or the default `{ type, data }` wrapper) discriminates at the **JSON** boundary while the **symbol brand** is only for in-process factory-built values; documents tradeoffs (brands lost on `JSON.stringify`, sample-level placement of JSON helpers vs adapter layer) and states **`EventSerializer` / `SnapshotSerializer` APIs stay unchanged**.
> 
> Adds formal **spec scenarios** (brand checks, round-trip, thin aliases for existing `convertJSONTo*` helpers) and a new **tasks section 6** listing pending implementation, tests, README/migration updates, and validation commands. **No library or sample code** is modified in this PR—only OpenSpec artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4232d7ba4494bbab5ea10a4cd2463b923eb55255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->