### PR TITLE
Review Thread Resolution の check 名を分離する

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -32,12 +32,15 @@ concurrency:
 
 jobs:
   unresolved-comments:
-    name: Check unresolved comments
+    # Keep this Actions job name distinct from the synthetic required check-run
+    # named "Check unresolved comments" so cancelled workflow runs are not
+    # confused with the current branch-protection result.
+    name: Evaluate unresolved comments
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.pull_request != null || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Check unresolved comments
+      - name: Evaluate review-thread state
         env:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
@@ -168,11 +171,10 @@ jobs:
               local check_run_error
               local existing_check_run_id
               local check_run_url
-              local create_if_missing="false"
-
-              if [[ "$EVENT_NAME" == "issue_comment" || "$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
-                create_if_missing="true"
-              fi
+              # The synthetic check is the stable required context. Create it
+              # on every eligible event because the Actions job intentionally
+              # uses a distinct name for UI clarity.
+              local create_if_missing="true"
 
               if (( ${#check_summary} > max_summary_chars )); then
                 truncation_suffix=$'\n\n... truncated for GitHub Checks API summary limit ...'


### PR DESCRIPTION
## 概要

- Review Thread Resolution の Actions job 名を `Evaluate unresolved comments` に変更
- job 内の step 名を `Evaluate review-thread state` に変更
- synthetic check-run 名 `Check unresolved comments` は維持し、required check 名との互換性を保つ

## 背景

Actions job と synthetic check-run が同じ `Check unresolved comments` 名だったため、cancelled になった historical workflow run と、現在 branch protection を塞いでいる synthetic check-run failure が PR checks 上で判別しづらくなっていました。

## 確認

- `git diff --check`
- `yq '.' .github/workflows/review-thread-resolution.yml >/dev/null`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-thread-resolution.yml`

Closes #934

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only naming and when the synthetic check is created; required check name and merge-gating logic are unchanged.
> 
> **Overview**
> The **Review Thread Resolution** workflow now uses different display names for the Actions job/step versus the required status check, so cancelled workflow runs are easier to tell apart from the live **Check unresolved comments** synthetic check on the PR.
> 
> The Actions job is renamed to **Evaluate unresolved comments** and its main step to **Evaluate review-thread state**; the API-published check name **Check unresolved comments** is unchanged for branch protection. The workflow also always creates the synthetic check when missing (instead of only on `issue_comment`, `schedule`, or `workflow_dispatch`), with comments explaining that the job name is for UI clarity while the check name stays the stable required context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e342e74e233602ec5075aa7a3c30103a04a8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions ワークフローの内部命名規則と説明コメントを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/event-store-adapter-js/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->