### PR TITLE
bump-version ワークフローを手動実行のみにする

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,8 +1,6 @@
 name: Bump-Version
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
 jobs:
   bump-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
- `.github/workflows/bump-version.yml` から `schedule` トリガーを削除
- `workflow_dispatch` は残し、Actions 画面の手動実行ボタンからのみ起動できるように変更

## 確認
- `git diff --check`
- `yq '.' .github/workflows/bump-version.yml >/dev/null`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/bump-version.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only removes an automated schedule from a release workflow; no application or security logic changes.
> 
> **Overview**
> The **Bump-Version** GitHub Actions workflow no longer runs on a weekly cron (`0 0 * * 1`). It is triggered only via **`workflow_dispatch`**, so version bumps must be started manually from the Actions UI.
> 
> The job steps (semver calculation, package bump, tag, release, snapshot) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab87c9287e755893b06ea4151860586a94aeeb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->