### PR TITLE
Spanner のスナップショット保持仕様を DynamoDB と揃える

### DIFF
--- a/packages/library/src/internal/default-shard-selector.test.ts
+++ b/packages/library/src/internal/default-shard-selector.test.ts
@@ -4,7 +4,7 @@ import { createDefaultShardSelector } from "./default-shard-selector";
 import { UserAccountId } from "./test/user-account-id";
 
 describe("DefaultShardSelector", () => {
-  function selectLegacyDynamoDBShardId(
+  function selectLegacyShardId(
     aggregateId: UserAccountId,
     shardCount: number,
   ): number {
@@ -32,7 +32,7 @@ describe("DefaultShardSelector", () => {
     ).toBe(ShardId.create(shardId));
   });
 
-  test("matches the legacy DynamoDB shard hash coercion", () => {
+  test("matches the legacy shard hash coercion", () => {
     const shardCount = ShardCount.create(32);
     const selector = createDefaultShardSelector<UserAccountId>();
     const ids = [
@@ -43,7 +43,7 @@ describe("DefaultShardSelector", () => {
 
     for (const id of ids) {
       expect(selector.selectShardId(id, shardCount)).toBe(
-        ShardId.create(selectLegacyDynamoDBShardId(id, shardCount)),
+        ShardId.create(selectLegacyShardId(id, shardCount)),
       );
     }
   });

--- a/packages/library/src/internal/spanner-event-store.test.ts
+++ b/packages/library/src/internal/spanner-event-store.test.ts
@@ -92,6 +92,15 @@ function createFakeSpannerDatabase(options: FakeSpannerDatabaseOptions = {}) {
     options.failRetainedSnapshotSelectWith = error;
   }
 
+  function getRetainedSnapshotSequenceNumbers(aggregateId: string): number[] {
+    return Array.from(snapshotRows.values())
+      .filter(
+        (row) => row.aggregateId === aggregateId && row.sequenceNumber > 0,
+      )
+      .map((row) => row.sequenceNumber)
+      .sort((a, b) => a - b);
+  }
+
   async function run(request: FakeSqlRequest): Promise<[FakeRow[]]> {
     if (request.sql.includes("FROM `journal`")) {
       return [selectJournalRows(requireParams(request))];
@@ -386,6 +395,7 @@ function createFakeSpannerDatabase(options: FakeSpannerDatabaseOptions = {}) {
     run,
     runTransactionAsync,
     runUpdate,
+    getRetainedSnapshotSequenceNumbers,
     setFailRetainedSnapshotSelectWith,
   };
   return Object.freeze(fakeDatabase);
@@ -573,6 +583,42 @@ describe("SpannerEventStore", () => {
 
     const latestSnapshot = await eventStore.getLatestSnapshotById(id);
     expect(latestSnapshot?.name).toBe("Bob");
+  });
+
+  test("purges existing retained snapshots when keepSnapshotCount is zero", async () => {
+    const database = createFakeSpannerDatabase();
+    const retainedEventStore = createFakeEventStore(2, database);
+    const id = UserAccountId.create(ulid());
+    const [userAccount1, created] = UserAccount.create(id, "Alice");
+    await expectOk(
+      retainedEventStore.persistEventAndSnapshot(created, userAccount1),
+    );
+
+    const [userAccount2, renamedToBob] = userAccount1.rename("Bob");
+    await expectOk(
+      retainedEventStore.persistEventAndSnapshot(renamedToBob, userAccount2),
+    );
+    expect(database.getRetainedSnapshotSequenceNumbers(id.asString())).toEqual([
+      1, 2,
+    ]);
+
+    const zeroRetentionEventStore = createFakeEventStore(0, database);
+    const snapshotAfterBob =
+      await zeroRetentionEventStore.getLatestSnapshotById(id);
+    if (snapshotAfterBob === undefined) {
+      throw new Error("snapshotAfterBob is undefined");
+    }
+    const [userAccount3, renamedToCarol] = snapshotAfterBob.rename("Carol");
+    await expectOk(
+      zeroRetentionEventStore.persistEventAndSnapshot(
+        renamedToCarol,
+        userAccount3,
+      ),
+    );
+
+    expect(database.getRetainedSnapshotSequenceNumbers(id.asString())).toEqual(
+      [],
+    );
   });
 
   test("converts duplicate journal inserts to optimistic lock conflict", async () => {

--- a/packages/library/src/internal/spanner-event-store.ts
+++ b/packages/library/src/internal/spanner-event-store.ts
@@ -381,7 +381,7 @@ function createSpannerEventStore<
   async function purgeExcessSnapshots(
     aggregateId: AID,
   ): Promise<EventStoreError | undefined> {
-    if (keepSnapshotCount === undefined || keepSnapshotCount === 0) {
+    if (keepSnapshotCount === undefined) {
       return undefined;
     }
     try {


### PR DESCRIPTION
## 概要

- Spanner 版で `keepSnapshotCount=0` のときも既存の retained snapshot を削除するように変更しました。
- `keepSnapshotCount` の意味を DynamoDB 版と揃え、`undefined` は保持処理無効、`0` は retained snapshot を 0 件保持、`>0` は最新 N 件保持として扱います。
- 共有 `DefaultShardSelector` のテスト名から DynamoDB 固有の名前を外しました。

## 背景

EventStore として DynamoDB 版と Spanner 版の snapshot retention 仕様に差が出ないようにするためです。DynamoDB 固有の `deleteTtlMillis` は DynamoDB TTL 向けの storage-specific option のままにし、Spanner 側には追加していません。

## 確認

- `pnpm --filter event-store-adapter-js exec jest src/internal/spanner-event-store.test.ts src/internal/default-shard-selector.test.ts --runInBand --no-cache`
- `pnpm --filter event-store-adapter-js exec biome check src/internal/spanner-event-store.ts src/internal/spanner-event-store.test.ts src/internal/default-shard-selector.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snapshot purge behavior on persist paths; misconfiguration could delete retained history, though scope is limited to Spanner adapter retention logic covered by new tests.
> 
> **Overview**
> Aligns **Spanner** snapshot retention with the **DynamoDB** event store: `keepSnapshotCount` is now **`undefined`** = no retention/purge, **`0`** = keep zero retained rows (and purge existing `sequence_number > 0` copies), **`> 0`** = keep the newest N retained snapshots.
> 
> **`purgeExcessSnapshots`** no longer skips work when the count is zero—only when retention is unset—so switching to `keepSnapshotCount: 0` clears snapshots that were kept under a higher limit. A fake-database test asserts retained sequence numbers go from `[1, 2]` to `[]` after a persist with zero retention.
> 
> **`DefaultShardSelector`** tests are renamed to drop DynamoDB-specific wording (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c00a61b60efc64cc52ca7e46749575e000c4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->