### PR TITLE
Node.js 24 に実行環境を統一する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       TEST_TIME_FACTOR: 10.0
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
     steps:
       - name: Checkout source
         uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@11.3.0",
   "engines": {
-    "node": ">=22.13"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "pnpm --filter event-store-adapter-js run build",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -4,7 +4,7 @@
   "description": "This library is designed to turn DynamoDB into an Event Store for Event Sourcing.",
   "packageManager": "pnpm@11.3.0",
   "engines": {
-    "node": ">=22.13"
+    "node": ">=24.0.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## 概要
- root と library package の `engines.node` を `>=24.0.0` に更新
- CI の test matrix を `24.x` に更新
- lint / release / snapshot / 型定義の Node 24 指定と揃える

## 背景
pnpm 11 の最低要件は Node 22.13 以上ですが、このリポジトリでは lint / release / snapshot workflow と `@types/node` がすでに Node 24 系です。CI test だけ `22.x`、package engines が `>=22.13` のままだと実行基準が分散するため、公開パッケージのサポート範囲と CI 実行環境を Node 24 に統一します。

## 検証
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm --filter event-store-adapter-js run coverage --runInBand`
- `yq '.jobs.test.strategy.matrix."node-version"' .github/workflows/ci.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and CI matrix updates only; no runtime code, auth, or data-path changes.
> 
> **Overview**
> This PR **aligns the supported and tested Node.js baseline to 24** across the workspace and CI.
> 
> The root and `event-store-adapter-js` package **`engines.node`** requirements move from **`>=22.13`** to **`>=24.0.0`**, so consumers and local tooling are told to run on Node 24+. The CI **test** job matrix switches from **`22.x`** to **`24.x`**, matching the lint job’s existing Node 24 setup and the library’s `@types/node` ^24 line.
> 
> There is **no application or library logic change**—only runtime/version policy and where tests execute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aceb941dc790521ff5ccc674a66b0f6f8d894e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Node.js の最小バージョン要件を 24.0.0 に更新
  * CI テスト環境を Node.js 24.x に更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/event-store-adapter-js/pull/939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->