### PR TITLE
CodeRabbit と Codecov の自動レポートを未確認コメント判定から除外

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -641,8 +641,10 @@ jobs:
             # Ignore generated report comments that do not require PR-author acknowledgement.
             unacknowledged_top_level="$(
               jq -c --arg pr_author "$pr_author" --arg pr_author_type "$pr_author_type" '
+                def report_author_login:
+                  (.author.login // "") | sub("\\[bot\\]$"; "");
                 def ignored_auto_report:
-                  (.author.login // "") as $author
+                  report_author_login as $author
                   | (.body // "") as $body
                   | (
                       $author == "coderabbitai"

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -514,6 +514,7 @@ jobs:
                             }
                             nodes {
                               url
+                              body
                               createdAt
                               updatedAt
                               authorAssociation
@@ -617,6 +618,7 @@ jobs:
                   | map(select((.body // "") != "" and .state != "DISMISSED"))
                   | map({
                       url,
+                      body,
                       createdAt: .submittedAt,
                       updatedAt: (.updatedAt // .submittedAt),
                       authorAssociation,
@@ -636,13 +638,27 @@ jobs:
               page=$((page + 1))
             done
 
+            # Ignore generated report comments that do not require PR-author acknowledgement.
             unacknowledged_top_level="$(
               jq -c --arg pr_author "$pr_author" --arg pr_author_type "$pr_author_type" '
+                def ignored_auto_report:
+                  (.author.login // "") as $author
+                  | (.body // "") as $body
+                  | (
+                      $author == "coderabbitai"
+                      and ($body | contains("<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"))
+                    )
+                    or (
+                      $author == "codecov"
+                      and ($body | startswith("## [Codecov]("))
+                      and ($body | contains(" Report"))
+                    );
                 . as $comments
                 | [
                     $comments[]
                     | select(
-                        ((.author.login // "") != $pr_author)
+                        (ignored_auto_report | not)
+                        and ((.author.login // "") != $pr_author)
                         and (
                           $pr_author_type != "Bot"
                           or (


### PR DESCRIPTION
## 概要
- Review Thread Resolution workflow の top-level / review summary 判定でコメント本文を取得するようにしました。
- CodeRabbit の自動 summary レポートと Codecov Report コメントを未ack候補から除外しました。
- `coderabbitai[bot]` / `codecov[bot]` 形式の author login でも判定できるよう `[bot]` サフィックスを正規化しています。
- inline review thread は従来どおり未解決判定の対象に残しています。

## 確認
- `yq '.' .github/workflows/review-thread-resolution.yml >/dev/null`
- `yq -r '.jobs."unresolved-comments".steps[0].run' .github/workflows/review-thread-resolution.yml | bash -n`
- PR #939 の実コメントデータで CodeRabbit / Codecov Report が未ack候補から除外されることを確認
- `[bot]` サフィックス付きの jq サンプルで CodeRabbit / Codecov Report が除外され、人間コメントは候補に残ることを確認

## 監視結果
- PR #940 の CI / Codecov / Review Thread Resolution / CodeRabbit / Cursor Bugbot / GitGuardian は pass
- 未解決 review thread は 0 件
- `mergeStateStatus=CLEAN`
