### PR TITLE
[codex] 共通ワークフロー参照ハッシュを更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,10 +347,10 @@ jobs:
       issues: read
       pull-requests: read
       statuses: write
-    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     with:
       wait_for_other_checks: "false"
-      ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a
 
   ci-success:
     name: CI Success

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   refresh:
     name: Refresh review-thread state
-    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     permissions:
       contents: read
       checks: write
@@ -44,4 +44,4 @@ jobs:
     with:
       pr_number: ${{ inputs.pr_number }}
       wait_for_other_checks: ${{ inputs.wait_for_other_checks || 'true' }}
-      ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a


### PR DESCRIPTION
## 概要

- .github/workflows/ci.yml の j5ik2o/ci reusable workflow 参照を最新 SHA に更新
- .github/workflows/review-thread-resolution.yml の j5ik2o/ci reusable workflow 参照を最新 SHA に更新
- uses と ci_ref を同じ j5ik2o/ci commit に揃える

## 理由

j5ik2o/ci が最新化されたため、呼び出し側 workflow の固定 SHA を最新の main HEAD 560170b61c74a9a643a483a052ccbad0d6ad409a に追従します。

## 検証

- yq parse for .github/workflows/ci.yml and .github/workflows/review-thread-resolution.yml
- actionlint for touched workflow files
- actionlint for all workflow files
- git diff --check --cached

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes pinned external workflow SHAs in GitHub Actions; no application or runtime code is affected.
> 
> **Overview**
> Pins the shared **`j5ik2o/ci`** reusable **review-thread-resolution** workflow to commit **`560170b61c74a9a643a483a052ccbad0d6ad409a`** instead of the previous SHA.
> 
> In **`.github/workflows/ci.yml`** (PR gate job) and **`.github/workflows/review-thread-resolution.yml`** (scheduled/event refresh job), both the **`uses:`** ref and the **`ci_ref`** input are updated to the same new hash so callers stay aligned with the latest **`j5ik2o/ci`** main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6445b353985c47c7ade0c2021292cd1976c3ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->